### PR TITLE
Revamp GatePlan UI and habit features

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,356 +1,1136 @@
-// GatePlan - local-first MVP
-const $ = (s) => document.querySelector(s);
-const $$ = (s) => document.querySelectorAll(s);
+// GatePlan 2.0 - modular, delightful, habit-safe PWA upgrade
+// This rewrite focuses on composable helpers, clear data modeling, and UI polish.
 
-const state = {
-  tasks: [],         // pool of tasks
-  todayPlan: [],     // items planned for yyyy-mm-dd
-  streak: 0,
-  lastCheckinDate: null,
-  settings: { morningHour: "07:00", calLinks: "on" },
+const $ = (selector, scope = document) => scope.querySelector(selector);
+const $$ = (selector, scope = document) => Array.from(scope.querySelectorAll(selector));
+
+const STORAGE_KEY = 'gateplan_state_v2';
+const DEFAULT_REASONS = {
+  success: [],
+  partial: ['Made progress', 'Need more time', 'Energy dipped'],
+  not_yet: ['Ran out of time', 'Blocked by something', 'Energy was low', 'Forgot', 'Chose rest'],
+  skipped: ['No longer relevant', 'Waiting on someone', 'Emergency came up', 'Reprioritized'],
 };
 
-function todayKey(d=new Date()) {
-  const y = d.getFullYear();
-  const m = String(d.getMonth()+1).padStart(2,"0");
-  const day = String(d.getDate()).padStart(2,"0");
-  return `${y}-${m}-${day}`;
+const DEFAULT_SETTINGS = {
+  morningHour: '07:00',
+  minTasks: 1,
+  calLinks: 'on',
+  streakThreshold: 0.8,
+  theme: 'system',
+  accentColor: '#6366f1',
+};
+
+let state = createInitialState();
+let deferredInstallPrompt = null;
+
+function createInitialState() {
+  return {
+    version: 2,
+    tasks: [],
+    days: [],
+    streak: 0,
+    bestStreak: 0,
+    streakHistory: [],
+    lastCheckinDate: null,
+    settings: { ...DEFAULT_SETTINGS },
+  };
 }
 
-function load() {
-  const saved = JSON.parse(localStorage.getItem("gp_state")||"{}");
-  Object.assign(state, saved);
-  if (!state.settings) state.settings = { morningHour:"07:00", calLinks:"on" };
-}
-function save() {
-  localStorage.setItem("gp_state", JSON.stringify(state));
+function todayKey(date = new Date()) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
-function initDemoIfEmpty() {
-  if (state.tasks.length===0) {
-    state.tasks.push(
-      {id:crypto.randomUUID(), title:"30 min reading", defDur:30, due:null, tags:["focus"]},
-      {id:crypto.randomUUID(), title:"Workout", defDur:45, due:null, tags:["health"]},
-      {id:crypto.randomUUID(), title:"Deep work block", defDur:60, due:null, tags:["study"]},
-    );
+function migrateState(raw) {
+  const base = createInitialState();
+  if (!raw || typeof raw !== 'object') return base;
+
+  const merged = { ...base, ...raw };
+  merged.settings = { ...DEFAULT_SETTINGS, ...(raw.settings || {}) };
+
+  merged.tasks = Array.isArray(raw.tasks)
+    ? raw.tasks
+        .map((task) => ({
+          id: task?.id || crypto.randomUUID(),
+          title: String(task?.title || 'Untitled task'),
+          defDur: Number(task?.defDur) || 30,
+          due: task?.due || null,
+          tags: Array.isArray(task?.tags)
+            ? task.tags.filter(Boolean)
+            : typeof task?.tags === 'string'
+            ? task.tags.split(',').map((t) => t.trim()).filter(Boolean)
+            : [],
+        }))
+    : base.tasks;
+
+  if (Array.isArray(raw.days)) {
+    merged.days = raw.days.map(normalizeDay).filter(Boolean);
+  } else if (Array.isArray(raw.todayPlan)) {
+    // Legacy structure -> migrate.
+    merged.days = raw.todayPlan.map((entry) => {
+      const items = Array.isArray(entry?.items)
+        ? entry.items.map((it) => normalizeItem({
+            id: it?.id || crypto.randomUUID(),
+            title: it?.title || 'Task',
+            start: it?.start || null,
+            duration: Number(it?.duration) || Number(it?.defDur) || 30,
+            status: it?.status || null,
+            partial: typeof it?.partial === 'number' ? it.partial : 100,
+            reasons: it?.reason ? [String(it.reason)] : Array.isArray(it?.reasons) ? it.reasons : [],
+            note: it?.note || '',
+            taskId: it?.taskId || null,
+          }))
+        : [];
+      return normalizeDay({
+        date: entry?.date,
+        items,
+        planned: !!entry?.planned,
+        checked: !!entry?.checked,
+        freeTomorrow: !!entry?.freeTomorrow,
+        summary: entry?.summary || null,
+      });
+    });
+  } else {
+    merged.days = base.days;
+  }
+
+  merged.streak = Number(raw.streak) || 0;
+  merged.bestStreak = Number(raw.bestStreak) || merged.streak || 0;
+  merged.streakHistory = Array.isArray(raw.streakHistory)
+    ? raw.streakHistory
+        .map((row) => ({ date: row?.date || todayKey(), streak: Number(row?.streak) || 0 }))
+        .slice(-120)
+    : [];
+  merged.lastCheckinDate = raw.lastCheckinDate || null;
+
+  return merged;
+}
+
+function normalizeDay(day) {
+  if (!day?.date) return null;
+  return {
+    date: day.date,
+    items: Array.isArray(day.items) ? day.items.map(normalizeItem).filter(Boolean) : [],
+    planned: !!day.planned,
+    checked: !!day.checked,
+    freeTomorrow: !!day.freeTomorrow,
+    summary: day.summary || null,
+  };
+}
+
+function normalizeItem(item) {
+  if (!item) return null;
+  return {
+    id: item.id || crypto.randomUUID(),
+    taskId: item.taskId || null,
+    title: item.title || 'Task',
+    start: item.start || null,
+    duration: Number(item.duration) || 30,
+    status: item.status || null,
+    partial: typeof item.partial === 'number' ? clamp(item.partial, 0, 100) : item.status === 'success' ? 100 : 0,
+    reasons: Array.isArray(item.reasons)
+      ? item.reasons.filter(Boolean)
+      : item.reason
+      ? [String(item.reason)]
+      : [],
+    note: item.note || '',
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function loadState() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return createInitialState();
+    const parsed = JSON.parse(saved);
+    return migrateState(parsed);
+  } catch (error) {
+    console.error('Failed to parse saved GatePlan state', error);
+    return createInitialState();
   }
 }
 
-function renderDateInfo() {
-  $("#dateInfo").textContent = (new Date()).toDateString();
-  $("#streakInfo").textContent = `Streak: ${state.streak} 🔥`;
+function saveState() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    updateLastSync();
+  } catch (error) {
+    console.error('Unable to persist GatePlan state', error);
+  }
 }
 
-function setTab(tabId) {
-  $$(".tab").forEach(b => b.classList.remove("active"));
-  $(`#tab-${tabId}`).classList.add("active");
-  $$(".view").forEach(v => v.classList.remove("visible"));
-  $(`#view-${tabId}`).classList.add("visible");
+function updateLastSync() {
+  const stamp = new Date();
+  $('#lastSync').textContent = `Last saved ${stamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+function ensureDay(dateKey = todayKey()) {
+  let day = state.days.find((entry) => entry.date === dateKey);
+  if (!day) {
+    day = normalizeDay({ date: dateKey, items: [], planned: false, checked: false, freeTomorrow: false });
+    state.days.push(day);
+  }
+  return day;
+}
+
+function ensureDemoTasks() {
+  if (state.tasks.length > 0) return;
+  state.tasks.push(
+    { id: crypto.randomUUID(), title: 'Deep work sprint', defDur: 60, due: null, tags: ['focus'] },
+    { id: crypto.randomUUID(), title: 'Movement / workout', defDur: 45, due: null, tags: ['health'] },
+    { id: crypto.randomUUID(), title: 'Read 30 pages', defDur: 30, due: null, tags: ['learning'] }
+  );
+}
+
+function hydrateUI() {
+  renderDateInfo();
+  renderTasks();
+  renderTodayViews();
+  renderCheckinList();
+  renderReview();
+  applySettingsToUI();
+  applyTheme();
+  updateOfflineBanner();
+  maybeShowGate();
+}
+
+function renderDateInfo() {
+  $('#dateInfo').textContent = new Date().toLocaleDateString(undefined, {
+    weekday: 'long', month: 'long', day: 'numeric'
+  });
+  $('#streakInfo').textContent = `Streak: ${state.streak} 🔥`;
+}
+
+function renderTasks() {
+  renderPoolSelect();
+  renderPoolList();
+}
+
+function renderTodayViews() {
+  renderTodayPlanList();
+  renderTodayLiveList();
+  updatePlanSummary();
+  updateTodayProgress();
 }
 
 function renderPoolSelect() {
-  const sel = $("#planTaskSelect");
-  sel.innerHTML = "";
-  state.tasks.forEach(t => {
-    const opt = document.createElement("option");
-    opt.value = t.id;
-    opt.textContent = t.title;
-    sel.appendChild(opt);
+  const select = $('#planTaskSelect');
+  select.innerHTML = '';
+  if (!state.tasks.length) {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'Add tasks to your pool first';
+    select.append(opt);
+    select.disabled = true;
+    return;
+  }
+  select.disabled = false;
+  state.tasks.forEach((task, idx) => {
+    const opt = document.createElement('option');
+    opt.value = task.id;
+    opt.textContent = task.title;
+    if (idx === 0) opt.selected = true;
+    select.append(opt);
   });
 }
 
 function renderPoolList() {
-  const ul = $("#poolList");
-  ul.innerHTML = "";
-  state.tasks.forEach(t => {
-    const li = document.createElement("li");
-    const left = document.createElement("div");
-    const right = document.createElement("div");
-    left.innerHTML = `<strong>${t.title}</strong> <span class="badge">${t.defDur}m</span> ${t.due?`<span class="small">due ${t.due}</span>`:""} ${t.tags?.length? `<span class="small">#${t.tags.join(", #")}</span>`:""}`;
-    const del = document.createElement("button"); del.textContent="Delete";
-    del.addEventListener("click", ()=>{
-      state.tasks = state.tasks.filter(x=>x.id!==t.id); save(); renderPoolList(); renderPoolSelect();
+  const list = $('#poolList');
+  list.innerHTML = '';
+  if (!state.tasks.length) {
+    list.innerHTML = `<li class="empty-state">No tasks yet. Capture a few go-to moves to speed up planning.</li>`;
+    return;
+  }
+  state.tasks.forEach((task) => {
+    const li = document.createElement('li');
+    const header = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = task.title;
+    header.append(title);
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+    const duration = document.createElement('span');
+    duration.className = 'badge';
+    duration.textContent = `${task.defDur} min`;
+    meta.append(duration);
+    if (task.due) {
+      const due = document.createElement('span');
+      due.className = 'badge';
+      due.textContent = `Due ${task.due}`;
+      meta.append(due);
+    }
+    if (task.tags?.length) {
+      const tags = document.createElement('span');
+      tags.textContent = `#${task.tags.join(', #')}`;
+      meta.append(tags);
+    }
+    const actions = document.createElement('div');
+    actions.className = 'card-actions';
+    const deleteBtn = document.createElement('button');
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.className = 'danger';
+    deleteBtn.addEventListener('click', () => {
+      if (!confirm(`Remove "${task.title}" from the pool?`)) return;
+      state.tasks = state.tasks.filter((t) => t.id !== task.id);
+      saveState();
+      renderTasks();
     });
-    right.appendChild(del);
-    li.append(left, right);
-    ul.appendChild(li);
+    actions.append(deleteBtn);
+    li.append(header, meta, actions);
+    list.append(li);
   });
 }
 
-function getTodayPlan() {
-  const key = todayKey();
-  if (!state.todayPlan) state.todayPlan = [];
-  if (!state.todayPlan.find(d=>d.date===key)) {
-    state.todayPlan.push({ date:key, items:[], planned:false, checked:false, freeTomorrow:false });
-  }
-  return state.todayPlan.find(d=>d.date===key);
-}
-
 function renderTodayPlanList() {
-  const todays = getTodayPlan();
-  const ul = $("#todayPlanList");
-  ul.innerHTML = "";
-  todays.items.sort((a,b)=>(a.start||"").localeCompare(b.start||""));
-  todays.items.forEach((it, idx)=>{
-    const li = document.createElement("li");
-    const left = document.createElement("div");
-    const right = document.createElement("div");
-    left.innerHTML = `<strong>${it.title}</strong> ${it.start?`<span class="badge">${it.start}</span>`:""} <span class="badge">${it.duration}m</span>`;
-    // Calendar link
-    if (state.settings.calLinks==="on") {
-      const a = document.createElement("a");
-      a.textContent = "Add to Google Calendar";
-      a.href = makeGCalLink(it);
-      a.target = "_blank";
-      a.className = "small";
-      left.appendChild(document.createElement("br"));
-      left.appendChild(a);
+  const list = $('#todayPlanList');
+  list.innerHTML = '';
+  const day = ensureDay();
+  if (!day.items.length) {
+    list.innerHTML = `<li class="empty-state">No tasks planned yet. Add at least ${state.settings.minTasks} to unlock the day.</li>`;
+    return;
+  }
+
+  const sorted = [...day.items].sort((a, b) => {
+    if (!a.start && !b.start) return 0;
+    if (!a.start) return 1;
+    if (!b.start) return -1;
+    return a.start.localeCompare(b.start);
+  });
+
+  sorted.forEach((item) => {
+    const li = document.createElement('li');
+    li.dataset.id = item.id;
+    const header = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = item.title;
+    header.append(title);
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+    if (item.start) {
+      const start = document.createElement('span');
+      start.className = 'badge';
+      start.textContent = item.start;
+      meta.append(start);
     }
-    const rm = document.createElement("button"); rm.textContent="Remove";
-    rm.addEventListener("click", ()=>{
-      todays.items.splice(idx,1); save(); renderTodayPlanList(); renderTodayLiveList(); renderCheckinList(); maybeShowGate();
+    const duration = document.createElement('span');
+    duration.className = 'badge';
+    duration.textContent = `${item.duration} min`;
+    meta.append(duration);
+    const actions = document.createElement('div');
+    actions.className = 'card-actions';
+    if (state.settings.calLinks === 'on') {
+      const link = document.createElement('a');
+      link.href = makeGCalLink(item);
+      link.target = '_blank';
+      link.rel = 'noreferrer';
+      link.textContent = 'Add to Google Calendar';
+      link.className = 'muted';
+      actions.append(link);
+    }
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', () => {
+      const today = ensureDay();
+      today.items = today.items.filter((it) => it.id !== item.id);
+      if (today.items.length < state.settings.minTasks) {
+        today.planned = false;
+      }
+      saveState();
+      renderTodayViews();
+      renderCheckinList();
+      maybeShowGate();
     });
-    right.appendChild(rm);
-    li.append(left,right);
-    ul.appendChild(li);
+    actions.append(removeBtn);
+    li.append(header, meta, actions);
+    list.append(li);
   });
 }
 
 function renderTodayLiveList() {
-  const todays = getTodayPlan();
-  const ul = $("#todayLiveList");
-  ul.innerHTML = "";
-  if (todays.items.length===0) {
-    const p = document.createElement("p");
-    p.className="muted";
-    p.textContent = "No tasks planned yet. Go to Morning Plan.";
-    ul.appendChild(p);
+  const list = $('#todayLiveList');
+  list.innerHTML = '';
+  const day = ensureDay();
+  if (!day.items.length) {
+    list.innerHTML = `<li class="empty-state">All clear. Plan tasks to see them here.</li>`;
     return;
   }
-  todays.items.forEach((it)=>{
-    const li = document.createElement("li");
-    li.innerHTML = `<div><strong>${it.title}</strong> ${it.start?`<span class="badge">${it.start}</span>`:""} <span class="badge">${it.duration}m</span></div>`;
-    ul.appendChild(li);
+  day.items.forEach((item) => {
+    const li = document.createElement('li');
+    const header = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = item.title;
+    header.append(title);
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+    if (item.start) {
+      const start = document.createElement('span');
+      start.className = 'badge';
+      start.textContent = item.start;
+      meta.append(start);
+    }
+    const duration = document.createElement('span');
+    duration.className = 'badge';
+    duration.textContent = `${item.duration} min`;
+    meta.append(duration);
+    header.append(meta);
+
+    const statusWrap = document.createElement('div');
+    if (item.status) {
+      const statusTag = document.createElement('span');
+      statusTag.className = `status-tag ${item.status}`;
+      statusTag.textContent = formatStatusLabel(item);
+      statusWrap.append(statusTag);
+    } else {
+      const placeholder = document.createElement('span');
+      placeholder.className = 'muted';
+      placeholder.textContent = 'Awaiting check-in';
+      statusWrap.append(placeholder);
+    }
+
+    li.append(header, statusWrap);
+
+    if (item.note) {
+      const note = document.createElement('p');
+      note.className = 'muted';
+      note.textContent = item.note;
+      li.append(note);
+    }
+    list.append(li);
   });
+}
+
+function formatStatusLabel(item) {
+  if (item.status === 'partial') {
+    return `Partial ${item.partial || 0}%`;
+  }
+  if (item.status === 'not_yet') return 'Not yet';
+  if (item.status === 'skipped') return 'Skipped';
+  return 'Success';
+}
+
+function updatePlanSummary() {
+  const day = ensureDay();
+  const total = day.items.length;
+  const totalMinutes = day.items.reduce((acc, item) => acc + (item.duration || 0), 0);
+  $('#planSummary').textContent = total
+    ? `${total} task${total === 1 ? '' : 's'} • ${totalMinutes} minutes`
+    : 'No tasks yet.';
+  $('#planProgressLabel').textContent = `${total}/${state.settings.minTasks}`;
+  const progress = Math.min(1, total / Math.max(1, state.settings.minTasks));
+  $('#planProgressBar').style.width = `${progress * 100}%`;
+}
+
+function calculateCompletion(items) {
+  if (!items.length) return { weighted: 0, total: 0 };
+  const weighted = items.reduce((sum, item) => {
+    if (item.status === 'success') return sum + 1;
+    if (item.status === 'partial') return sum + (item.partial || 0) / 100;
+    return sum;
+  }, 0);
+  return { weighted, total: items.length };
+}
+
+function updateTodayProgress() {
+  const day = ensureDay();
+  const { weighted, total } = calculateCompletion(day.items);
+  const percent = total ? Math.round((weighted / total) * 100) : 0;
+  $('#todayProgressLabel').textContent = total ? `${weighted.toFixed(weighted % 1 === 0 ? 0 : 1)}/${total}` : '0/0';
+  $('#todayProgressBar').style.width = `${percent}%`;
 }
 
 function renderCheckinList() {
-  const todays = getTodayPlan();
-  const ul = $("#checkinList");
-  ul.innerHTML = "";
-  if (todays.items.length===0) {
-    const p = document.createElement("p");
-    p.className="muted";
-    p.textContent = "Nothing planned today.";
-    ul.appendChild(p);
+  const list = $('#checkinList');
+  list.innerHTML = '';
+  const day = ensureDay();
+  $('#tomorrowFree').checked = !!day.freeTomorrow;
+  if (!day.items.length) {
+    list.innerHTML = `<li class="empty-state">Plan today first. Your check-in awaits tonight.</li>`;
     return;
   }
-  todays.items.forEach((it)=>{
-    const li = document.createElement("li");
-    const left = document.createElement("div");
-    left.innerHTML = `<strong>${it.title}</strong> ${it.start?`<span class="badge">${it.start}</span>`:""} <span class="badge">${it.duration}m</span>`;
-
-    const right = document.createElement("div");
-    const success = document.createElement("button"); success.textContent="Success";
-    const notYet = document.createElement("button"); notYet.textContent="Not yet";
-    const skipped = document.createElement("button"); skipped.textContent="Skipped";
-
-    const reasons = ["underestimated","urgent_interruption","low_energy","blocked","procrastination","sick","technical_issue"];
-    const chips = document.createElement("div"); chips.className="chips"; chips.style.display="none";
-    reasons.forEach(r=>{
-      const c=document.createElement("div"); c.className="chip"; c.textContent=r.replace("_"," ");
-      c.addEventListener("click", ()=>{
-        chips.querySelectorAll(".chip").forEach(x=>x.classList.remove("selected"));
-        c.classList.add("selected");
-        it.reason = r;
-      });
-      chips.appendChild(c);
-    });
-
-    function mark(status){
-      it.status = status;
-      if (status==="success"){
-        chips.style.display="none";
-        it.reason=null;
-      } else {
-        chips.style.display="flex";
-      }
-    }
-
-    success.addEventListener("click", ()=>mark("success"));
-    notYet.addEventListener("click", ()=>mark("not_yet"));
-    skipped.addEventListener("click", ()=>mark("skipped"));
-
-    right.append(success, notYet, skipped);
-    li.append(left, right);
-    li.appendChild(chips);
-    ul.appendChild(li);
+  day.items.forEach((item, index) => {
+    list.append(renderCheckinItem(item, index));
   });
 }
 
-function makeGCalLink(it){
-  // Build a simple Google Calendar template link for today with start and duration
-  const key = todayKey();
-  const [y,m,d] = key.split("-").map(Number);
-  let start = it.start || "09:00";
-  const [hh,mm] = start.split(":").map(Number);
-  const startDate = new Date(y, m-1, d, hh, mm);
-  const endDate = new Date(startDate.getTime() + (it.duration||30)*60000);
+function renderCheckinItem(item, index) {
+  const li = document.createElement('li');
+  li.dataset.index = String(index);
+  const reasonSectionHidden = !item.status || item.status === 'success';
+  const sliderHidden = item.status !== 'partial';
+  const sliderValue = item.partial || 50;
+  const options = Array.from(new Set([...(DEFAULT_REASONS[item.status] || []), ...(item.reasons || [])]));
 
-  function fmt(d){
-    const pad = n => String(n).padStart(2,"0");
-    // Use local time; Google can parse UTC 'Z' or local with timezone-less; we'll provide UTC:
-    const y = d.getUTCFullYear();
-    const mo = pad(d.getUTCMonth()+1);
-    const da = pad(d.getUTCDate());
-    const h = pad(d.getUTCHours());
-    const mi = pad(d.getUTCMinutes());
-    const s = pad(d.getUTCSeconds());
-    return `${y}${mo}${da}T${h}${mi}${s}Z`;
+  const header = document.createElement('div');
+  const title = document.createElement('strong');
+  title.textContent = item.title;
+  header.append(title);
+  const meta = document.createElement('div');
+  meta.className = 'item-meta';
+  if (item.start) {
+    const start = document.createElement('span');
+    start.className = 'badge';
+    start.textContent = item.start;
+    meta.append(start);
   }
-  const dates = `${fmt(startDate)}/${fmt(endDate)}`;
-  const params = new URLSearchParams({
-    action: "TEMPLATE",
-    text: it.title,
-    dates,
-    details: "Planned via GatePlan",
+  const duration = document.createElement('span');
+  duration.className = 'badge';
+  duration.textContent = `${item.duration} min`;
+  meta.append(duration);
+  header.append(meta);
+  li.append(header);
+
+  const statusButtons = document.createElement('div');
+  statusButtons.className = 'status-buttons';
+  statusButtons.setAttribute('role', 'group');
+  statusButtons.setAttribute('aria-label', `Status for ${item.title}`);
+  ['success', 'partial', 'not_yet', 'skipped'].forEach((status) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'status-button';
+    if (item.status === status) btn.classList.add('active');
+    btn.dataset.status = status;
+    btn.textContent = statusLabel(status);
+    statusButtons.append(btn);
   });
-  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+  li.append(statusButtons);
+
+  const reasonSection = document.createElement('div');
+  reasonSection.className = `reason-section${reasonSectionHidden ? ' hidden' : ''}`;
+  reasonSection.dataset.role = 'reason-section';
+  const chipWrap = document.createElement('div');
+  chipWrap.className = 'chips';
+  chipWrap.dataset.role = 'reasons';
+  options.forEach((reason) => {
+    if (!reason) return;
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'chip';
+    if (item.reasons?.includes(reason)) chip.classList.add('selected');
+    chip.dataset.reason = reason;
+    chip.textContent = reason;
+    chipWrap.append(chip);
+  });
+  reasonSection.append(chipWrap);
+
+  const addReason = document.createElement('button');
+  addReason.type = 'button';
+  addReason.className = 'chip';
+  addReason.dataset.action = 'add-reason';
+  addReason.textContent = '+ Add reason';
+  reasonSection.append(addReason);
+
+  const sliderWrap = document.createElement('div');
+  sliderWrap.className = `slider-wrap${sliderHidden ? ' hidden' : ''}`;
+  sliderWrap.dataset.role = 'slider-wrap';
+  const sliderLabel = document.createElement('span');
+  sliderLabel.className = 'label';
+  const sliderValueEl = document.createElement('strong');
+  sliderValueEl.dataset.role = 'slider-value';
+  sliderValueEl.textContent = `${sliderValue}%`;
+  sliderLabel.append('Partial progress: ', sliderValueEl);
+  sliderWrap.append(sliderLabel);
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.min = '10';
+  slider.max = '100';
+  slider.step = '10';
+  slider.value = String(sliderValue);
+  slider.dataset.role = 'partial-slider';
+  sliderWrap.append(slider);
+  reasonSection.append(sliderWrap);
+
+  const noteField = document.createElement('label');
+  noteField.className = 'field';
+  const noteLabel = document.createElement('span');
+  noteLabel.className = 'label';
+  noteLabel.textContent = 'Note (optional)';
+  const textarea = document.createElement('textarea');
+  textarea.className = 'note';
+  textarea.dataset.role = 'note';
+  textarea.placeholder = 'Capture insights';
+  textarea.value = item.note || '';
+  noteField.append(noteLabel, textarea);
+  reasonSection.append(noteField);
+
+  li.append(reasonSection);
+  return li;
+}
+
+function statusLabel(status) {
+  switch (status) {
+    case 'success':
+      return 'Success';
+    case 'partial':
+      return 'Partial';
+    case 'not_yet':
+      return 'Not yet';
+    case 'skipped':
+      return 'Skipped';
+    default:
+      return status;
+  }
+}
+
+function renderReview() {
+  // Weekly review highlights successes, blockers, and streak momentum.
+  const lastSeven = [...state.days]
+    .filter((day) => day.items?.length)
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, 7);
+
+  const dailyList = $('#dailySuccessList');
+  dailyList.innerHTML = '';
+  if (!lastSeven.length) {
+    dailyList.innerHTML = '<li class="empty-state">Complete a few check-ins to see trends.</li>';
+  } else {
+    lastSeven.forEach((day) => {
+      const { weighted, total } = calculateCompletion(day.items);
+      const percent = total ? Math.round((weighted / total) * 100) : 0;
+      const li = document.createElement('li');
+      li.className = 'stat-item';
+      const dayLabel = document.createElement('span');
+      dayLabel.textContent = formatDate(day.date);
+      const bar = document.createElement('div');
+      bar.className = 'bar';
+      const fill = document.createElement('span');
+      fill.style.width = `${percent}%`;
+      bar.append(fill);
+      const pct = document.createElement('span');
+      pct.textContent = `${percent}%`;
+      li.append(dayLabel, bar, pct);
+      dailyList.append(li);
+    });
+  }
+
+  const reasonCounts = new Map();
+  lastSeven.forEach((day) => {
+    day.items.forEach((item) => {
+      if (item.status === 'success') return;
+      (item.reasons || []).forEach((reason) => {
+        if (!reason) return;
+        reasonCounts.set(reason, (reasonCounts.get(reason) || 0) + 1);
+      });
+    });
+  });
+  const reasonList = $('#topReasonsList');
+  reasonList.innerHTML = '';
+  if (!reasonCounts.size) {
+    reasonList.innerHTML = '<li class="empty-state">No reasons logged yet. Add them during check-in.</li>';
+  } else {
+    Array.from(reasonCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .forEach(([reason, count]) => {
+        const li = document.createElement('li');
+        li.className = 'stat-item';
+        const label = document.createElement('span');
+        label.textContent = reason;
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = String(count);
+        li.append(label, badge);
+        reasonList.append(li);
+      });
+  }
+
+  const streakSummary = $('#streakSummary');
+  streakSummary.innerHTML = '';
+  const history = state.streakHistory.slice(-5).reverse();
+  if (!history.length) {
+    streakSummary.innerHTML = '<div class="empty-state">Complete check-ins to build your streak story.</div>';
+  } else {
+    history.forEach((row) => {
+      const div = document.createElement('div');
+      div.className = 'streak-row';
+      const label = document.createElement('span');
+      label.textContent = formatDate(row.date);
+      const streak = document.createElement('strong');
+      streak.textContent = `${row.streak} 🔥`;
+      div.append(label, streak);
+      streakSummary.append(div);
+    });
+  }
+}
+
+function formatDate(dateKey) {
+  const [y, m, d] = dateKey.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+function makeGCalLink(item) {
+  const startDate = new Date();
+  const [hours, minutes] = (item.start || '08:00').split(':');
+  startDate.setHours(Number(hours), Number(minutes), 0, 0);
+  const end = new Date(startDate.getTime() + (item.duration || 30) * 60000);
+  const fmt = (date) => date.toISOString().replace(/[-:]|\.\d{3}/g, '');
+  const details = encodeURIComponent('Planned with GatePlan');
+  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(item.title)}&dates=${fmt(startDate)}/${fmt(end)}&details=${details}`;
 }
 
 function addToToday() {
-  const id = $("#planTaskSelect").value;
-  const t = state.tasks.find(x=>x.id===id);
-  if (!t) return;
-  const start = $("#planStartTime").value || "";
-  const dur = parseInt($("#planDuration").value || t.defDur || 30, 10);
-  const todays = getTodayPlan();
-  todays.items.push({title:t.title, start, duration: dur, status:null, reason:null});
-  save();
-  renderTodayPlanList(); renderTodayLiveList(); renderCheckinList(); maybeShowGate();
+  const day = ensureDay();
+  const taskId = $('#planTaskSelect').value;
+  if (!taskId) {
+    alert('Add tasks to your pool first.');
+    return;
+  }
+  const task = state.tasks.find((t) => t.id === taskId);
+  if (!task) {
+    alert('Task not found in pool.');
+    return;
+  }
+  const duration = Number($('#planDuration').value) || task.defDur || 30;
+  const newItem = normalizeItem({
+    id: crypto.randomUUID(),
+    taskId: task.id,
+    title: task.title,
+    start: $('#planStartTime').value || null,
+    duration,
+    status: null,
+    partial: 0,
+    reasons: [],
+    note: '',
+  });
+  day.items.push(newItem);
+  $('#planDuration').value = '';
+  saveState();
+  renderTodayViews();
+  renderCheckinList();
+  maybeShowGate();
 }
 
 function finishPlanning() {
-  const todays = getTodayPlan();
-  if (todays.items.length===0) {
-    alert("Add at least one task to Today.");
+  const day = ensureDay();
+  if (day.items.length < state.settings.minTasks) {
+    alert(`Please plan at least ${state.settings.minTasks} task${state.settings.minTasks === 1 ? '' : 's'} before unlocking the day.`);
     return;
   }
-  todays.planned = true;
-  save();
+  day.planned = true;
+  day.checked = false;
+  day.freeTomorrow = false;
+  saveState();
   maybeShowGate();
-  alert("Great! Planning saved.");
+  toast('Plan locked in. Have a focused day!');
+}
+
+function handleCheckinListClick(event) {
+  const li = event.target.closest('li[data-index]');
+  if (!li) return;
+  const index = Number(li.dataset.index);
+  const day = ensureDay();
+  const item = day.items[index];
+  if (!item) return;
+
+  const statusBtn = event.target.closest('.status-button');
+  if (statusBtn) {
+    const status = statusBtn.dataset.status;
+    item.status = status;
+    if (status === 'success') {
+      item.reasons = [];
+      item.partial = 100;
+    } else if (status === 'partial') {
+      item.partial = item.partial || 50;
+    } else {
+      item.partial = 0;
+    }
+    saveState();
+    replaceCheckinItem(index);
+    renderTodayLiveList();
+    return;
+  }
+
+  const chip = event.target.closest('.chip[data-reason]');
+  if (chip) {
+    const reason = chip.dataset.reason;
+    if (item.reasons?.includes(reason)) {
+      item.reasons = item.reasons.filter((r) => r !== reason);
+    } else {
+      item.reasons = [...(item.reasons || []), reason];
+    }
+    saveState();
+    replaceCheckinItem(index);
+    return;
+  }
+
+  const addReason = event.target.closest('[data-action="add-reason"]');
+  if (addReason) {
+    const userReason = prompt('Add a quick reason');
+    if (userReason) {
+      item.reasons = [...(item.reasons || []), userReason.trim()];
+      saveState();
+      replaceCheckinItem(index);
+    }
+    return;
+  }
+}
+
+function handleCheckinListInput(event) {
+  const li = event.target.closest('li[data-index]');
+  if (!li) return;
+  const index = Number(li.dataset.index);
+  const day = ensureDay();
+  const item = day.items[index];
+  if (!item) return;
+
+  if (event.target.matches('[data-role="partial-slider"]')) {
+    const value = Number(event.target.value);
+    item.partial = value;
+    item.status = 'partial';
+    saveState();
+    const row = $('#checkinList').querySelector(`li[data-index="${index}"]`);
+    if (row) {
+      const label = $('[data-role="slider-value"]', row);
+      if (label) label.textContent = `${value}%`;
+      $$('.status-button', row).forEach((btn) => {
+        btn.classList.toggle('active', btn.dataset.status === 'partial');
+      });
+      $('[data-role="reason-section"]', row)?.classList.remove('hidden');
+      $('[data-role="slider-wrap"]', row)?.classList.remove('hidden');
+    }
+    renderTodayLiveList();
+    return;
+  }
+
+  if (event.target.matches('[data-role="note"]')) {
+    item.note = event.target.value;
+    saveState();
+    renderTodayLiveList();
+  }
+}
+
+function replaceCheckinItem(index) {
+  const list = $('#checkinList');
+  const row = list.querySelector(`li[data-index="${index}"]`);
+  if (!row) return;
+  const day = ensureDay();
+  const updated = renderCheckinItem(day.items[index], index);
+  row.replaceWith(updated);
 }
 
 function submitCheckin() {
-  const todays = getTodayPlan();
-  // Validate reasons
-  for (const it of todays.items) {
-    if ((it.status==="not_yet" || it.status==="skipped") && !it.reason) {
-      alert(`Please choose a reason for "${it.title}".`);
+  const day = ensureDay();
+  if (!day.items.length) {
+    alert('Nothing planned. Add tasks first.');
+    return;
+  }
+  for (const item of day.items) {
+    if (!item.status) {
+      alert(`Please select a status for "${item.title}".`);
       return;
     }
-    if (!it.status) {
-      alert(`Please mark a status for "${it.title}".`);
+    if ((item.status === 'not_yet' || item.status === 'skipped') && (!item.reasons?.length && !item.note?.trim())) {
+      alert(`Add at least one reason or a note for "${item.title}".`);
       return;
     }
   }
-  todays.checked = true;
-  // Streak logic: success if all are success OR the day was declared free
-  const allSuccess = todays.items.length>0 && todays.items.every(it=>it.status==="success");
-  if (allSuccess || $("#tomorrowFree").checked) {
-    state.streak = (state.streak||0) + 1;
+
+  const { weighted, total } = calculateCompletion(day.items);
+  const ratio = total ? weighted / total : 0;
+  day.checked = true;
+  day.freeTomorrow = $('#tomorrowFree').checked;
+  day.summary = { weighted, total, ratio, completedAt: new Date().toISOString() };
+  state.lastCheckinDate = todayKey();
+
+  const threshold = state.settings.streakThreshold || DEFAULT_SETTINGS.streakThreshold;
+  const qualifies = day.freeTomorrow || ratio >= threshold;
+  if (qualifies) {
+    state.streak += 1;
+    state.bestStreak = Math.max(state.bestStreak, state.streak);
   } else {
     state.streak = 0;
   }
-  state.lastCheckinDate = todayKey();
-  // Free tomorrow flag
-  todays.freeTomorrow = !!$("#tomorrowFree").checked;
-  save();
-  $("#checkinResult").textContent = "Check-in saved. Nice work!";
+  state.streakHistory.push({ date: state.lastCheckinDate, streak: state.streak });
+  state.streakHistory = state.streakHistory.slice(-120);
+
+  saveState();
   renderDateInfo();
+  renderTodayViews();
+  renderReview();
+  $('#checkinResult').textContent = qualifies
+    ? `Great reflection! ${Math.round(ratio * 100)}% success keeps the streak alive.`
+    : `Logged. ${Math.round(ratio * 100)}% — tomorrow is a fresh start.`;
+
+  if (qualifies) {
+    launchConfetti();
+  }
+}
+
+function toast(message) {
+  $('#checkinResult').textContent = message;
 }
 
 function maybeShowGate() {
-  // Show the gate in the morning if not planned and current time is after morning hour
-  const gate = $("#gate");
-  const todays = getTodayPlan();
-  const [mh, mm] = (state.settings.morningHour||"07:00").split(":").map(Number);
+  const overlay = $('#gate');
+  const day = ensureDay();
+  const [hour, minute] = (state.settings.morningHour || '07:00').split(':').map(Number);
   const now = new Date();
-  const gateTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), mh, mm, 0);
-  const shouldGate = (now >= gateTime) && !todays.planned && !todays.freeToday;
-  gate.classList.toggle("hidden", !shouldGate);
+  const gateTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minute || 0, 0);
+  const needsPlan = day.items.length < state.settings.minTasks || !day.planned;
+  const shouldShow = now >= gateTime && needsPlan && !day.checked;
+  overlay.classList.toggle('hidden', !shouldShow);
+  overlay.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+  $('#minTaskRequirement').textContent = `${state.settings.minTasks} task${state.settings.minTasks === 1 ? '' : 's'}`;
 }
 
-function wireUI() {
-  $("#tab-plan").addEventListener("click", ()=>{setTab("plan")});
-  $("#tab-today").addEventListener("click", ()=>{setTab("today"); renderTodayLiveList();});
-  $("#tab-pool").addEventListener("click", ()=>{setTab("pool")});
-  $("#tab-checkin").addEventListener("click", ()=>{setTab("checkin")});
-  $("#tab-settings").addEventListener("click", ()=>{setTab("settings")});
-
-  $("#addToToday").addEventListener("click", addToToday);
-  $("#finishPlanning").addEventListener("click", finishPlanning);
-  $("#addPoolTask").addEventListener("click", ()=>{
-    const title = $("#poolTitle").value.trim();
-    const defDur = parseInt($("#poolDuration").value||"30",10);
-    const due = $("#poolDue").value || null;
-    const tags = $("#poolTags").value ? $("#poolTags").value.split(",").map(s=>s.trim()).filter(Boolean): [];
-    if (!title) { alert("Enter a title"); return; }
-    state.tasks.push({id:crypto.randomUUID(), title, defDur, due, tags});
-    $("#poolTitle").value=""; $("#poolDuration").value=""; $("#poolDue").value=""; $("#poolTags").value="";
-    save(); renderPoolSelect(); renderPoolList();
+function setTab(tabId) {
+  $$('.tab-button').forEach((btn) => {
+    const active = btn.id === `tab-${tabId}`;
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-selected', String(active));
   });
-
-  $("#saveSettings").addEventListener("click", ()=>{
-    state.settings.morningHour = $("#morningHour").value || "07:00";
-    state.settings.calLinks = $("#calLinks").value || "on";
-    save(); alert("Settings saved.");
+  $$('.view').forEach((view) => {
+    view.classList.toggle('visible', view.id === `view-${tabId}`);
   });
+  if (tabId === 'review') {
+    renderReview();
+  }
+}
 
-  $("#gateGo").addEventListener("click", ()=>{
-    setTab("plan");
-  });
+function applySettingsToUI() {
+  $('#morningHour').value = state.settings.morningHour;
+  $('#minTasks').value = state.settings.minTasks;
+  $('#calLinks').value = state.settings.calLinks;
+  $('#streakThreshold').value = String(state.settings.streakThreshold);
+  $('#themeChoice').value = state.settings.theme;
+  $('#accentColor').value = state.settings.accentColor;
+}
 
-  window.addEventListener("focus", ()=>{
-    renderDateInfo(); maybeShowGate();
-  });
+function updateSettings() {
+  state.settings.morningHour = $('#morningHour').value || DEFAULT_SETTINGS.morningHour;
+  state.settings.minTasks = clamp(Number($('#minTasks').value) || DEFAULT_SETTINGS.minTasks, 1, 20);
+  state.settings.calLinks = $('#calLinks').value;
+  state.settings.streakThreshold = Number($('#streakThreshold').value) || DEFAULT_SETTINGS.streakThreshold;
+  state.settings.theme = $('#themeChoice').value;
+  state.settings.accentColor = $('#accentColor').value || DEFAULT_SETTINGS.accentColor;
+  saveState();
+  applyTheme();
+  maybeShowGate();
+  renderTodayViews();
+  toast('Settings saved.');
+}
 
-  // Installation prompt
-  let deferredPrompt = null;
-  window.addEventListener('beforeinstallprompt', (e) => {
-    e.preventDefault();
-    deferredPrompt = e;
-    $("#installBtn").classList.remove("hidden");
-  });
-  $("#installBtn").addEventListener("click", async ()=>{
-    $("#installBtn").classList.add("hidden");
-    if (deferredPrompt) {
-      deferredPrompt.prompt();
-      await deferredPrompt.userChoice;
-      deferredPrompt = null;
+function applyTheme() {
+  const root = document.documentElement;
+  let theme = state.settings.theme;
+  if (theme === 'system') {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  root.dataset.theme = theme;
+  root.style.setProperty('--accent', state.settings.accentColor);
+  root.style.setProperty('--accent-soft', hexToRgba(state.settings.accentColor, 0.15));
+}
+
+function hexToRgba(hex, alpha) {
+  const parsed = hex.replace('#', '');
+  if (parsed.length !== 6) return `rgba(99,102,241,${alpha})`;
+  const bigint = parseInt(parsed, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function updateOfflineBanner() {
+  // Provide immediate visual feedback for offline/online transitions.
+  const banner = $('#offlineBanner');
+  if (!navigator.onLine) {
+    banner.classList.add('active');
+    $('#offlineText').textContent = 'Offline mode: changes stored locally';
+  } else {
+    banner.classList.remove('active');
+    $('#offlineText').textContent = 'Back online';
+  }
+}
+
+function exportData() {
+  try {
+    const blob = new Blob([JSON.stringify(state, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `gateplan-backup-${todayKey()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    alert('Unable to export data.');
+    console.error(error);
+  }
+}
+
+function importData(file) {
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (event) => {
+    try {
+      // Resilient backup restore with migration to the latest schema.
+      const parsed = JSON.parse(event.target.result);
+      state = migrateState(parsed);
+      ensureDay();
+      ensureDemoTasks();
+      saveState();
+      hydrateUI();
+      toast('Import complete. Welcome back!');
+    } catch (error) {
+      alert('Invalid backup file.');
+      console.error('Import failed', error);
     }
-  });
+  };
+  reader.readAsText(file);
+}
+
+function launchConfetti() {
+  // Lightweight celebration animation to reinforce streak wins.
+  const canvas = $('#confettiCanvas');
+  const ctx = canvas.getContext('2d');
+  const pieces = Array.from({ length: 120 }, () => createConfettiPiece(canvas));
+  let animationFrame;
+  let start = null;
+
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+  resize();
+  canvas.classList.remove('hidden');
+
+  function step(timestamp) {
+    if (!start) start = timestamp;
+    const progress = timestamp - start;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    pieces.forEach((piece) => {
+      piece.y += piece.speed;
+      piece.x += Math.sin((progress / 200 + piece.drift) * piece.drift) * 2;
+      if (piece.y > canvas.height) piece.y = -20;
+      ctx.fillStyle = piece.color;
+      ctx.fillRect(piece.x, piece.y, piece.size, piece.size * 0.6);
+    });
+    if (progress < 1800) {
+      animationFrame = requestAnimationFrame(step);
+    } else {
+      canvas.classList.add('hidden');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      cancelAnimationFrame(animationFrame);
+    }
+  }
+
+  animationFrame = requestAnimationFrame(step);
+  setTimeout(() => {
+    window.addEventListener('resize', resize, { once: true });
+  }, 0);
+}
+
+function createConfettiPiece(canvas) {
+  const colors = [state.settings.accentColor, '#f97316', '#22c55e', '#facc15'];
+  return {
+    x: Math.random() * canvas.width,
+    y: Math.random() * canvas.height,
+    size: Math.random() * 12 + 6,
+    speed: Math.random() * 3 + 2,
+    color: colors[Math.floor(Math.random() * colors.length)],
+    drift: Math.random() * 2,
+  };
 }
 
 function registerSW() {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('./service-worker.js');
+    navigator.serviceWorker.register('./service-worker.js').catch((err) => {
+      console.warn('Service worker registration failed', err);
+    });
   }
 }
 
+function initEventListeners() {
+  $('#tab-plan').addEventListener('click', () => setTab('plan'));
+  $('#tab-today').addEventListener('click', () => setTab('today'));
+  $('#tab-pool').addEventListener('click', () => setTab('pool'));
+  $('#tab-checkin').addEventListener('click', () => setTab('checkin'));
+  $('#tab-review').addEventListener('click', () => setTab('review'));
+  $('#tab-settings').addEventListener('click', () => setTab('settings'));
+
+  $('#addToToday').addEventListener('click', addToToday);
+  $('#finishPlanning').addEventListener('click', finishPlanning);
+
+  $('#addPoolTask').addEventListener('click', () => {
+    const title = $('#poolTitle').value.trim();
+    const defDur = Number($('#poolDuration').value) || 30;
+    const due = $('#poolDue').value || null;
+    const tags = $('#poolTags').value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    if (!title) {
+      alert('Please enter a title.');
+      return;
+    }
+    state.tasks.push({ id: crypto.randomUUID(), title, defDur, due, tags });
+    $('#poolForm').reset();
+    saveState();
+    renderTasks();
+    renderTodayPlanList();
+  });
+
+  $('#saveSettings').addEventListener('click', updateSettings);
+
+  $('#gateGo').addEventListener('click', () => {
+    setTab('plan');
+    $('#gate').classList.add('hidden');
+  });
+
+  $('#submitCheckin').addEventListener('click', submitCheckin);
+
+  $('#checkinList').addEventListener('click', handleCheckinListClick);
+  $('#checkinList').addEventListener('input', handleCheckinListInput);
+
+  window.addEventListener('focus', () => {
+    renderDateInfo();
+    maybeShowGate();
+  });
+
+  window.addEventListener('online', updateOfflineBanner);
+  window.addEventListener('offline', updateOfflineBanner);
+
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', applyTheme);
+
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredInstallPrompt = event;
+    $('#installBtn').classList.remove('hidden');
+  });
+
+  $('#installBtn').addEventListener('click', async () => {
+    $('#installBtn').classList.add('hidden');
+    if (!deferredInstallPrompt) return;
+    deferredInstallPrompt.prompt();
+    await deferredInstallPrompt.userChoice;
+    deferredInstallPrompt = null;
+  });
+
+  $('#exportData').addEventListener('click', exportData);
+  $('#importData').addEventListener('click', () => $('#importFile').click());
+  $('#importFile').addEventListener('change', (event) => {
+    const [file] = event.target.files;
+    importData(file);
+    event.target.value = '';
+  });
+}
+
 function init() {
-  load();
-  initDemoIfEmpty();
-  renderDateInfo();
-  renderPoolSelect();
-  renderPoolList();
-  renderTodayPlanList();
-  renderTodayLiveList();
-  renderCheckinList();
-  setTab("plan");
-  maybeShowGate();
-  wireUI();
+  state = loadState();
+  ensureDay();
+  ensureDemoTasks();
+  hydrateUI();
+  initEventListeners();
+  setTab('plan');
   registerSW();
 }
-document.addEventListener("DOMContentLoaded", init);
+
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -1,147 +1,259 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>GatePlan</title>
-  <meta name="theme-color" content="#0F4C81">
+  <meta name="theme-color" content="#101828">
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="stylesheet" href="styles.css">
-  <link rel="icon" type="image/png" sizes="192x192" href="icons/icon-192.png">
-  <link rel="apple-touch-icon" href="icons/icon-192.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="icon-192.png">
+  <link rel="apple-touch-icon" href="icon-192.png">
 </head>
 <body>
-  <header class="topbar">
-    <h1>GatePlan</h1>
-    <nav>
-      <button id="tab-plan" class="tab active">Morning Plan</button>
-      <button id="tab-today" class="tab">Today</button>
-      <button id="tab-pool" class="tab">Task Pool</button>
-      <button id="tab-checkin" class="tab">Evening Check-in</button>
-      <button id="tab-settings" class="tab">Settings</button>
+  <div id="app-shell">
+    <header class="app-header" role="banner">
+      <div class="brand">
+        <span class="logo">⏳</span>
+        <div>
+          <h1>GatePlan</h1>
+          <p class="tagline">Intentional days start here</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        <span id="dateInfo" class="date"></span>
+        <span id="streakInfo" class="streak">Streak: 0 🔥</span>
+      </div>
+      <button id="installBtn" class="ghost hidden" type="button">Install</button>
+    </header>
+
+    <!-- Persistent offline indicator for upgraded PWA feedback -->
+    <div id="offlineBanner" class="offline-banner" role="status" aria-live="polite">
+      <span class="dot"></span>
+      <span id="offlineText">Working offline</span>
+    </div>
+
+    <nav class="tab-bar" role="tablist" aria-label="GatePlan views">
+      <button class="tab-button active" id="tab-plan" role="tab" aria-selected="true" aria-controls="view-plan">Plan</button>
+      <button class="tab-button" id="tab-today" role="tab" aria-controls="view-today">Today</button>
+      <button class="tab-button" id="tab-pool" role="tab" aria-controls="view-pool">Task Pool</button>
+      <button class="tab-button" id="tab-checkin" role="tab" aria-controls="view-checkin">Check-in</button>
+      <button class="tab-button" id="tab-review" role="tab" aria-controls="view-review">Weekly Review</button>
+      <button class="tab-button" id="tab-settings" role="tab" aria-controls="view-settings">Settings</button>
     </nav>
-  </header>
 
-  <main>
-    <!-- Gate Overlay -->
-    <section id="gate" class="overlay hidden">
-      <div class="card">
-        <h2>Good morning 👋</h2>
-        <p>Before anything else, plan at least one task for today.</p>
-        <button id="gateGo">Open Morning Planner</button>
-      </div>
-    </section>
-
-    <!-- Morning Plan -->
-    <section id="view-plan" class="view visible">
-      <div class="card">
-        <h2>Plan your day</h2>
-        <div class="row">
-          <label>Pick a task from pool:</label>
-          <select id="planTaskSelect"></select>
+    <main class="views" role="main">
+      <!-- Morning gate overlay keeps the habit strong -->
+      <section id="gate" class="overlay hidden" aria-hidden="true">
+        <div class="overlay-card" role="dialog" aria-modal="true" aria-labelledby="gateTitle">
+          <h2 id="gateTitle">Morning gate</h2>
+          <p>Plan at least <strong id="minTaskRequirement">one task</strong> before the day begins.</p>
+          <button id="gateGo" class="primary" type="button">Plan today’s focus</button>
         </div>
-        <div class="row">
-          <label>Start time</label>
-          <input type="time" id="planStartTime">
-        </div>
-        <div class="row">
-          <label>Duration (min)</label>
-          <input type="number" id="planDuration" min="5" step="5" placeholder="30">
-        </div>
-        <button id="addToToday">Add to Today</button>
-      </div>
+      </section>
 
-      <div class="card">
-        <h3>Today’s Plan</h3>
-        <ul id="todayPlanList"></ul>
-        <div class="row">
-          <button id="finishPlanning" class="primary">Finish planning ✅</button>
+      <!-- Plan view -->
+      <section id="view-plan" class="view visible" role="tabpanel" aria-labelledby="tab-plan">
+        <div class="card intro">
+          <h2>Plan your deep work</h2>
+          <p class="muted">Grab tasks from your pool, set the intention, and lock in today’s focus.</p>
         </div>
-      </div>
-    </section>
+        <div class="card">
+          <form id="planForm" class="responsive-grid" autocomplete="off">
+            <label class="field">
+              <span class="label">Pick a task</span>
+              <select id="planTaskSelect"></select>
+            </label>
+            <label class="field">
+              <span class="label">Start time</span>
+              <input type="time" id="planStartTime">
+            </label>
+            <label class="field">
+              <span class="label">Duration (min)</span>
+              <input type="number" id="planDuration" min="5" step="5" placeholder="30">
+            </label>
+            <div class="field add-actions">
+              <button id="addToToday" class="primary" type="button">Add to today</button>
+            </div>
+          </form>
+        </div>
 
-    <!-- Today -->
-    <section id="view-today" class="view">
-      <div class="card">
-        <h2>Today</h2>
-        <ul id="todayLiveList"></ul>
-      </div>
-    </section>
-
-    <!-- Task Pool -->
-    <section id="view-pool" class="view">
-      <div class="card">
-        <h2>Task pool</h2>
-        <div class="grid2">
-          <div>
-            <label>Title</label>
-            <input id="poolTitle" placeholder="e.g., 30 min reading">
-          </div>
-          <div>
-            <label>Default duration (min)</label>
-            <input id="poolDuration" type="number" min="5" step="5" placeholder="30">
+        <div class="card">
+          <header class="card-header">
+            <div>
+              <h3>Today’s plan</h3>
+              <p class="muted" id="planSummary">No tasks yet.</p>
+            </div>
+            <div class="progress-pill" aria-live="polite">
+              <span id="planProgressLabel">0/0</span>
+              <div class="progress-track" aria-hidden="true">
+                <div id="planProgressBar" class="progress-fill" style="width:0%"></div>
+              </div>
+            </div>
+          </header>
+          <ul id="todayPlanList" class="list"></ul>
+          <div class="card-actions">
+            <button id="finishPlanning" class="primary" type="button">Lock plan ✅</button>
           </div>
         </div>
-        <div class="grid2">
-          <div>
-            <label>Due date (optional)</label>
-            <input id="poolDue" type="date">
+      </section>
+
+      <!-- Today view -->
+      <section id="view-today" class="view" role="tabpanel" aria-labelledby="tab-today">
+        <div class="card">
+          <header class="card-header">
+            <div>
+              <h2>Today</h2>
+              <p class="muted">Stay on track and celebrate progress.</p>
+            </div>
+            <div class="progress-pill">
+              <span id="todayProgressLabel">0/0</span>
+              <div class="progress-track" aria-hidden="true">
+                <div id="todayProgressBar" class="progress-fill" style="width:0%"></div>
+              </div>
+            </div>
+          </header>
+          <ul id="todayLiveList" class="list"></ul>
+        </div>
+      </section>
+
+      <!-- Task pool view -->
+      <section id="view-pool" class="view" role="tabpanel" aria-labelledby="tab-pool">
+        <div class="card">
+          <h2>Task pool</h2>
+          <p class="muted">Capture repeatable actions so planning stays fast.</p>
+          <form id="poolForm" class="responsive-grid" autocomplete="off">
+            <label class="field">
+              <span class="label">Title</span>
+              <input id="poolTitle" placeholder="e.g., 30 minute reading block">
+            </label>
+            <label class="field">
+              <span class="label">Default duration (min)</span>
+              <input id="poolDuration" type="number" min="5" step="5" placeholder="30">
+            </label>
+            <label class="field">
+              <span class="label">Due date</span>
+              <input id="poolDue" type="date">
+            </label>
+            <label class="field">
+              <span class="label">Tags</span>
+              <input id="poolTags" placeholder="focus, study">
+            </label>
+            <div class="field add-actions">
+              <button id="addPoolTask" class="primary" type="button">Add to pool</button>
+            </div>
+          </form>
+        </div>
+        <div class="card">
+          <h3>Saved tasks</h3>
+          <ul id="poolList" class="list"></ul>
+        </div>
+      </section>
+
+      <!-- Evening check-in -->
+      <section id="view-checkin" class="view" role="tabpanel" aria-labelledby="tab-checkin">
+        <div class="card">
+          <h2>Evening check-in</h2>
+          <p class="muted">Reflect and log why items stuck or slipped. Multiple reasons and notes encouraged.</p>
+          <ul id="checkinList" class="list"></ul>
+          <div class="card section">
+            <label class="field checkbox">
+              <input type="checkbox" id="tomorrowFree">
+              <span>Make tomorrow a free day</span>
+            </label>
           </div>
-          <div>
-            <label>Tags (comma-separated)</label>
-            <input id="poolTags" placeholder="focus, study">
+          <button id="submitCheckin" class="primary" type="button">Submit check-in</button>
+          <p id="checkinResult" class="muted" role="status" aria-live="polite"></p>
+        </div>
+      </section>
+
+      <!-- Weekly review -->
+      <section id="view-review" class="view" role="tabpanel" aria-labelledby="tab-review">
+        <div class="card">
+          <h2>Weekly review</h2>
+          <p class="muted">Zoom out to spot trends, celebrate streaks, and notice blockers.</p>
+          <div class="review-grid">
+            <div class="review-card">
+              <h3>Daily success rate</h3>
+              <ul id="dailySuccessList" class="stat-list"></ul>
+            </div>
+            <div class="review-card">
+              <h3>Top reasons</h3>
+              <ul id="topReasonsList" class="stat-list"></ul>
+            </div>
+            <div class="review-card">
+              <h3>Streak history</h3>
+              <div id="streakSummary" class="streak-summary"></div>
+            </div>
           </div>
         </div>
-        <button id="addPoolTask">Add to pool</button>
-      </div>
+      </section>
 
-      <div class="card">
-        <h3>Pool</h3>
-        <ul id="poolList"></ul>
-      </div>
-    </section>
-
-    <!-- Evening Check-in -->
-    <section id="view-checkin" class="view">
-      <div class="card">
-        <h2>Evening Check-in</h2>
-        <p>Mark each planned item. If not success, pick a reason.</p>
-        <ul id="checkinList"></ul>
-        <div class="row">
-          <label><input type="checkbox" id="tomorrowFree"> Make tomorrow a free day</label>
+      <!-- Settings -->
+      <section id="view-settings" class="view" role="tabpanel" aria-labelledby="tab-settings">
+        <div class="card">
+          <h2>Settings</h2>
+          <div class="settings-grid">
+            <label class="field">
+              <span class="label">Morning gate hour</span>
+              <input type="time" id="morningHour" value="07:00">
+            </label>
+            <label class="field">
+              <span class="label">Minimum tasks required</span>
+              <input type="number" id="minTasks" min="1" max="10" value="1">
+            </label>
+            <label class="field">
+              <span class="label">Calendar links</span>
+              <select id="calLinks">
+                <option value="on">On</option>
+                <option value="off">Off</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="label">Streak success threshold</span>
+              <select id="streakThreshold">
+                <option value="0.6">60%</option>
+                <option value="0.7">70%</option>
+                <option value="0.8">80%</option>
+                <option value="0.9">90%</option>
+                <option value="1">100%</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="label">Theme</span>
+              <select id="themeChoice">
+                <option value="system">Follow system</option>
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </label>
+            <label class="field">
+              <span class="label">Accent color</span>
+              <input type="color" id="accentColor" value="#6366f1">
+            </label>
+          </div>
+          <div class="card-actions">
+            <button id="saveSettings" class="primary" type="button">Save settings</button>
+          </div>
         </div>
-        <button id="submitCheckin" class="primary">Submit Check-in</button>
-        <p id="checkinResult" class="muted"></p>
-      </div>
-    </section>
-
-    <!-- Settings -->
-    <section id="view-settings" class="view">
-      <div class="card">
-        <h2>Settings</h2>
-        <div class="row">
-          <label>Morning gate hour (24h, e.g., 07:00)</label>
-          <input type="time" id="morningHour" value="07:00">
+        <div class="card">
+          <h3>Backup &amp; restore</h3>
+          <p class="muted">Everything stays on your device. Export a backup or bring one back.</p>
+          <div class="card-actions">
+            <button id="exportData" type="button">Export JSON</button>
+            <button id="importData" type="button">Import JSON</button>
+            <input id="importFile" type="file" accept="application/json" hidden>
+          </div>
         </div>
-        <div class="row">
-          <label>Google Calendar link on tasks</label>
-          <select id="calLinks">
-            <option value="on" selected>On</option>
-            <option value="off">Off</option>
-          </select>
-        </div>
-        <button id="saveSettings">Save Settings</button>
-        <p class="muted">Tip: On Android Chrome, tap ⋮ → Add to Home screen to install the app.</p>
-      </div>
-    </section>
-  </main>
+      </section>
+    </main>
 
-  <footer class="footer">
-    <span id="streakInfo">Streak: 0 🔥</span>
-    <span id="dateInfo"></span>
-    <button id="installBtn" class="ghost hidden">Install</button>
-  </footer>
+    <footer class="app-footer" role="contentinfo">
+      <span id="lastSync" class="muted">Local-first, auto-saved</span>
+    </footer>
+  </div>
 
-  <script src="app.js"></script>
+  <canvas id="confettiCanvas" class="confetti hidden" aria-hidden="true"></canvas>
+  <script src="app.js" type="module"></script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -3,17 +3,17 @@
   "short_name": "GatePlan",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#0F4C81",
-  "theme_color": "#0F4C81",
+  "background_color": "#101828",
+  "theme_color": "#101828",
   "icons": [
     {
-      "src": "icons/icon-192.png",
+      "src": "icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "icons/icon-512.png",
+      "src": "icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,28 +1,60 @@
-// Simple cache-first service worker for GatePlan
-const CACHE = 'gateplan-v1';
+// Enhanced cache-first service worker for GatePlan 2.0
+const CACHE = 'gateplan-v2';
 const ASSETS = [
   './',
   './index.html',
   './styles.css',
   './app.js',
   './manifest.webmanifest',
-  './icons/icon-192.png',
-  './icons/icon-512.png'
+  './icon-192.png',
+  './icon-512.png',
 ];
 
-self.addEventListener('install', (e)=>{
-  e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ASSETS)));
-});
-
-self.addEventListener('activate', (e)=>{
-  e.waitUntil(
-    caches.keys().then(keys=>Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll(ASSETS)).catch((error) => {
+      console.error('Asset caching failed', error);
+    })
   );
 });
 
-self.addEventListener('fetch', (e)=>{
-  const req = e.request;
-  e.respondWith(
-    caches.match(req).then(cached=> cached || fetch(req))
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE).then((cache) => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => caches.match('./index.html'))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) return cached;
+      return fetch(request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE).then((cache) => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => cached);
+    })
   );
 });

--- a/styles.css
+++ b/styles.css
@@ -1,29 +1,642 @@
-*{box-sizing:border-box}html,body{margin:0;padding:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:#f5f7fb;color:#0b1b2b}
-.topbar{position:sticky;top:0;background:#0F4C81;color:#fff;padding:10px 12px;display:flex;align-items:center;gap:12px;z-index:10}
-.topbar h1{margin:0;font-size:20px}
-.topbar nav{display:flex;gap:8px;flex-wrap:wrap}
-.tab{background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.2);color:#fff;padding:6px 10px;border-radius:10px;cursor:pointer}
-.tab.active{background:#fff;color:#0F4C81}
-main{padding:12px;max-width:900px;margin:0 auto}
-.card{background:#fff;border:1px solid #e5eaf2;border-radius:14px;padding:12px;box-shadow:0 2px 10px rgba(12,32,60,0.05);margin-bottom:12px}
-.row{display:flex;gap:8px;align-items:center;margin:8px 0}
-.grid2{display:grid;grid-template-columns:1fr 1fr;gap:8px}
-label{font-size:14px;color:#223b52;display:block}
-input,select,button{padding:8px 10px;border:1px solid #d6deea;border-radius:10px;font-size:14px}
-button.primary{background:#0F4C81;color:#fff;border-color:#0F4C81}
-button.ghost{background:transparent;border:1px dashed #9fb4cc;color:#0F4C81}
-ul{list-style:none;padding:0;margin:0}
-li{padding:8px;border:1px solid #e5eaf2;border-radius:10px;margin:6px 0;display:flex;justify-content:space-between;align-items:center;gap:8px}
-.badge{font-size:12px;padding:2px 6px;border-radius:6px;background:#eef4ff;color:#0F4C81;border:1px solid #cfe0ff}
-.small{font-size:12px;color:#4a627a}
-.muted{color:#5c738a}
-.footer{position:sticky;bottom:0;background:#f5f7fb;border-top:1px solid #e5eaf2;padding:10px 12px;display:flex;justify-content:space-between;align-items:center}
-.view{display:none}
-.view.visible{display:block}
-.overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center}
-.overlay.hidden{display:none}
-.overlay .card{max-width:420px}
-/* Chips */
-.chips{display:flex;gap:6px;flex-wrap:wrap}
-.chip{padding:6px 8px;border:1px solid #cbd9eb;border-radius:16px;cursor:pointer}
-.chip.selected{background:#0F4C81;color:#fff;border-color:#0F4C81}
+/* Modern theming tokens enabling responsive light/dark palettes */
+:root {
+  color-scheme: light;
+  --bg: #f5f6fa;
+  --surface: #ffffff;
+  --surface-alt: #eef2ff;
+  --text: #101828;
+  --text-muted: #4b5563;
+  --border: rgba(15, 23, 42, 0.08);
+  --shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+  --radius: 18px;
+  --accent: #6366f1;
+  --accent-soft: rgba(99, 102, 241, 0.12);
+  --header-bg: rgba(255, 255, 255, 0.75);
+  --banner-offline: #f97316;
+  --success: #16a34a;
+  --warning: #fbbf24;
+  --danger: #ef4444;
+  font-size: 16px;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --surface: rgba(15, 23, 42, 0.85);
+  --surface-alt: rgba(99, 102, 241, 0.1);
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.16);
+  --shadow: 0 18px 36px rgba(2, 6, 23, 0.6);
+  --header-bg: rgba(15, 23, 42, 0.85);
+  --banner-offline: #f97316;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at top, rgba(99, 102, 241, 0.12), transparent 55%), var(--bg);
+  color: var(--text);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+}
+
+#app-shell {
+  width: min(960px, 100%);
+  padding: clamp(16px, 4vw, 32px);
+  display: grid;
+  gap: 16px;
+  min-height: 100vh;
+}
+
+.app-header {
+  position: sticky;
+  top: env(safe-area-inset-top, 0px);
+  z-index: 20;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--header-bg);
+  backdrop-filter: blur(16px);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 18px 22px;
+  box-shadow: var(--shadow);
+  gap: 16px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand .logo {
+  font-size: 32px;
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.brand h1 {
+  font-size: clamp(1.25rem, 2.2vw, 1.6rem);
+  margin: 0;
+  font-weight: 700;
+}
+
+.tagline {
+  margin: 2px 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.header-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 160px;
+  text-align: right;
+}
+
+.date {
+  font-weight: 500;
+}
+
+.streak {
+  font-size: 0.9rem;
+  color: var(--accent);
+}
+
+.ghost {
+  background: transparent;
+  border: 1px dashed var(--accent);
+  color: var(--accent);
+  padding: 8px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 180ms ease;
+}
+
+.ghost:hover,
+.ghost:focus-visible {
+  background: var(--accent-soft);
+  outline: none;
+}
+
+.offline-banner {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  background: var(--banner-offline);
+  color: #fff;
+  padding: 8px 14px;
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  box-shadow: var(--shadow);
+}
+
+.offline-banner.active {
+  display: inline-flex;
+}
+
+.offline-banner .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: currentColor;
+  animation: pulse 1.2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.6; transform: scale(0.9); }
+  50% { opacity: 1; transform: scale(1.15); }
+}
+
+.tab-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 8px;
+}
+
+.tab-button {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-muted);
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 200ms ease, transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+}
+
+.tab-button.active {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 10px 24px rgba(99, 102, 241, 0.35);
+  transform: translateY(-2px);
+}
+
+.tab-button:focus-visible {
+  outline: 3px solid rgba(99, 102, 241, 0.4);
+  outline-offset: 3px;
+}
+
+.views {
+  display: grid;
+  gap: 18px;
+}
+
+.view {
+  display: none;
+  animation: fadeIn 280ms ease forwards;
+}
+
+.view.visible {
+  display: block;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  padding: clamp(18px, 3vw, 26px);
+  display: grid;
+  gap: 18px;
+}
+
+.card.intro {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.16), transparent);
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.card-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.card.section {
+  border-style: dashed;
+  border-color: var(--border);
+}
+
+.progress-pill {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.progress-track {
+  width: 140px;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 280ms ease;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.list > li {
+  background: var(--surface-alt);
+  border-radius: calc(var(--radius) - 6px);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+  border: 1px solid transparent;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.list > li:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
+}
+
+.list strong {
+  font-size: 1rem;
+}
+
+.item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(99, 102, 241, 0.16);
+  color: var(--accent);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+
+label.field {
+  display: grid;
+  gap: 6px;
+}
+
+.label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+input,
+select,
+button,
+textarea {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  background: var(--surface-alt);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 12px 14px;
+  color: var(--text);
+  transition: border 200ms ease, box-shadow 200ms ease;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.22);
+}
+
+button {
+  border: none;
+  border-radius: 14px;
+  padding: 12px 18px;
+  background: var(--surface-alt);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.16);
+}
+
+button.primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+button.danger {
+  background: rgba(239, 68, 68, 0.16);
+  color: var(--danger);
+}
+
+.responsive-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+}
+
+.add-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.field.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+textarea.note {
+  min-height: 90px;
+  resize: vertical;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, transform 200ms ease;
+}
+
+.chip:hover {
+  transform: translateY(-1px);
+}
+
+.chip.selected {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.stat-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.stat-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stat-item .bar {
+  flex: 1;
+  height: 8px;
+  background: rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.stat-item .bar > span {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+
+.review-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.review-card {
+  background: var(--surface-alt);
+  border-radius: calc(var(--radius) - 6px);
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.streak-summary {
+  display: grid;
+  gap: 12px;
+}
+
+.streak-summary .streak-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--surface);
+  border-radius: calc(var(--radius) - 10px);
+  padding: 12px 16px;
+}
+
+.slider-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.slider-wrap input[type="range"] {
+  accent-color: var(--accent);
+}
+
+.app-footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding: 12px 0 24px;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(6px);
+  transition: opacity 220ms ease;
+}
+
+.overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.overlay-card {
+  background: var(--surface);
+  padding: 32px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  text-align: center;
+  display: grid;
+  gap: 18px;
+  max-width: 360px;
+}
+
+.confetti {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 50;
+}
+
+.confetti.hidden {
+  opacity: 0;
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    justify-content: center;
+    text-align: center;
+  }
+
+  .header-meta {
+    text-align: center;
+    min-width: auto;
+  }
+
+  .progress-track {
+    width: 100px;
+  }
+
+  .list > li {
+    padding: 14px;
+  }
+}
+
+.status-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.status-button {
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.status-button:hover {
+  transform: translateY(-1px);
+}
+
+.status-button.active[data-status="success"] {
+  background: rgba(22, 163, 74, 0.2);
+  border-color: rgba(22, 163, 74, 0.4);
+  color: var(--success);
+}
+
+.status-button.active[data-status="partial"] {
+  background: rgba(251, 191, 36, 0.2);
+  border-color: rgba(251, 191, 36, 0.4);
+  color: var(--warning);
+}
+
+.status-button.active[data-status="not_yet"] {
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(99, 102, 241, 0.4);
+  color: var(--accent);
+}
+
+.status-button.active[data-status="skipped"] {
+  background: rgba(239, 68, 68, 0.16);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: var(--danger);
+}
+
+.reason-section {
+  display: grid;
+  gap: 12px;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.status-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.status-tag.success { background: rgba(22, 163, 74, 0.16); color: var(--success); }
+.status-tag.partial { background: rgba(251, 191, 36, 0.18); color: var(--warning); }
+.status-tag.not_yet { background: rgba(99, 102, 241, 0.18); color: var(--accent); }
+.status-tag.skipped { background: rgba(239, 68, 68, 0.18); color: var(--danger); }
+
+.empty-state {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 32px 12px;
+}


### PR DESCRIPTION
## Summary
- refresh the GatePlan shell with a responsive tabbed layout, offline banner, progress visuals, and a new weekly review dashboard
- modularize state management and check-in flows to support multi-reason chips, partial success, configurable streak thresholds, and backup/restore with theme controls
- update PWA plumbing with refined theming metadata and a cache-first service worker that covers the new assets

## Testing
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68da9ea9609883208b360d9ab4b1a8ba